### PR TITLE
Fix missing pronunciation for letter K

### DIFF
--- a/index.html
+++ b/index.html
@@ -94,7 +94,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
         const SPEAK_MAP = {
             A: 'ah', B: 'buh', C: 'kuh', D: 'duh', E: 'eh',
             F: 'fuh', G: 'guh', H: 'huh', I: 'ih', J: 'juh',
-            L: 'luh', M: 'muh', N: 'nuh', O: 'oh', P: 'puh',
+            K: 'kuh', L: 'luh', M: 'muh', N: 'nuh', O: 'oh', P: 'puh',
             Q: 'kwuh', R: 'ruh', S: 'sss', T: 'tuh', U: 'uh',
             V: 'vuh', W: 'wuh', X: 'ks', Y: 'yuh', Z: 'zzz'
         }


### PR DESCRIPTION
## Summary
- add K sound to SPEAK_MAP in `index.html`

## Testing
- `npm test` *(fails: package.json missing)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_684ee3da284c8333a29186539e8e04b0