### PR TITLE
Fix Teachers font paths

### DIFF
--- a/index.html
+++ b/index.html
@@ -56,14 +56,14 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
         @font-face {
             font-family: 'Teachers';
-            src: url('fonts/Teachers/Teachers-Regular.ttf') format('truetype');
+            src: url('fonts/Teachers/static/Teachers-Regular.ttf') format('truetype');
             font-weight: normal;
             font-style: normal;
         }
 
         @font-face {
             font-family: 'Teachers';
-            src: url('fonts/Teachers/Teachers-Bold.ttf') format('truetype');
+            src: url('fonts/Teachers/static/Teachers-Bold.ttf') format('truetype');
             font-weight: bold;
             font-style: normal;
         }


### PR DESCRIPTION
## Summary
- correct file paths for Teachers font files so styles load properly

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_68502ccb6ba0833388485f4272e5aa58